### PR TITLE
Do system call and catch the return in vars,

### DIFF
--- a/lib/msf/ui/console/driver.rb
+++ b/lib/msf/ui/console/driver.rb
@@ -497,7 +497,9 @@ protected
 
         self.busy = true
         begin
-          system(line)
+          out, err, st = Open3.capture3(line)
+          print_line("out:\n" + out.to_s + "\nerr:\n" + err.to_s + "\nexit code:\n" + st.exitstatus.to_s)
+
         rescue ::Errno::EACCES, ::Errno::ENOENT
           print_error("Permission denied exec: #{line}")
         end


### PR DESCRIPTION
Fixes my problem in combination of armitage/msf/kali linux:
output of exec is not shown in armitage console
dunno why and if I am the only one who encountered this issue.

unsure if this fix exposes a possible security flaw,  if line is compromised? 
My thoughts.
shoud run in usercontext so nothing to worry about? 
Better than direct system call anyway?
Maybe a better output format can be found/should be used? 
Currently the fix is presenting all, analog to last print_status (exec...) above
Since I'm totally new to rb, someone else should please judge my change with respect to my security constrains please.


Tell us what this change does. If you're fixing a bug, please mention
the github issue number.

Please ensure you are submitting **from a unique branch** in your [repository](https://github.com/rapid7/metasploit-framework/pull/11086#issuecomment-445506416) to master in Rapid7's.

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] `use exploit/windows/smb/ms08_067_netapi`
- [ ] ...
- [x] **Verify** the thing does what it should
- [ ] **Verify** the thing does not do what it should not
- [ ] **Document** the thing and how it works ([Example](https://github.com/rapid7/metasploit-framework/blob/master/documentation/modules/post/multi/gather/aws_keys.md))

